### PR TITLE
increase request queue size to help with concurrency

### DIFF
--- a/server.py
+++ b/server.py
@@ -66,6 +66,7 @@ class CASServer(HTTPServer):
 
     def __init__(self, server_address, secret, data_dir, handler_class):
         super(CASServer, self).__init__(server_address, handler_class)
+        self.socket.listen(1000)
         self.secret = secret
         self.data_dir = data_dir
         self._ticket_map = {}


### PR DESCRIPTION
Increased the request queue size to 1000 on the underlying socket to solve a problem with application being unable to connect during high-concurrency testing.
